### PR TITLE
修复发送本地视频时的TypeError

### DIFF
--- a/model/makeMsg.js
+++ b/model/makeMsg.js
@@ -336,7 +336,7 @@ async function makeSendMsg (params, uin, adapter) {
       }
         break
       case 'video':
-        if (i.data.file.startsWith('http')) {
+        if (typeof i.data.file === "string" && i.data.file.startsWith('http')) {
           const path = TMP_DIR + '/' + randomUUID({ disableEntropyCache: true }) + '.mp4'
           if (await common.downFile(i.data.file, path)) {
             sendMsg.push(segment.video(path))


### PR DESCRIPTION
- 在进行 `startWith` 前先进行类型判断避免对 object 错误操作