### PR TITLE
fix(model): 修正转发消息中的用户昵称和ID字段

### DIFF
--- a/model/makeMsg.js
+++ b/model/makeMsg.js
@@ -444,8 +444,8 @@ async function makeForwardMsg (params, uin, adapter) {
       }
       let { sendMsg } = await makeSendMsg(data)
       forwardMsg.push({
-        nickname: msg.data.name,
-        user_id: Number(msg.data.uin),
+        nickname: msg.data.nickname,
+        user_id: Number(msg.data.user_id),
         message: sendMsg
       })
     }


### PR DESCRIPTION
将转发消息中的昵称和用户ID字段从 `name` 和 `uin` 更正为 `nickname` 和 `user_id`，
以匹配正确的数据结构。