### PR TITLE
fix(api): 修复表情表态接口使用 seq 参数

### DIFF
--- a/model/api.js
+++ b/model/api.js
@@ -369,14 +369,18 @@ async function getApiData (api, params = {}, name, uin, adapter, other = {}) {
        * @param code 表情ID
        * @param type 表情类型 EmojiType
        */
+      let seq = (await getMsg({ onebot_id: params.message_id }))?.seq
+      if (!seq) {
+        throw { message: "消息不存在", noLog: true };
+      }
       if (params.is_add) {
         await bot
           .pickGroup(params.group_id)
-          .setReaction?.(params.message_id, params.code, params.type || 1);
+          .setReaction?.(seq, params.code, params.type || 1);
       } else {
         await bot
           .pickGroup(params.group_id)
-          .delReaction?.(params.message_id, params.code, params.type || 1);
+          .delReaction?.(seq, params.code, params.type || 1);
       }
     },
 


### PR DESCRIPTION
将 setReaction 和 delReaction 方法的参数从 message_id 更改为 seq，
并在调用前通过 message_id 获取对应的 seq。如果消息不存在则抛出错误。