### PR TITLE
feat(model): 为API数据添加默认性别字段

### DIFF
--- a/model/api.js
+++ b/model/api.js
@@ -573,6 +573,9 @@ async function getApiData (api, params = {}, name, uin, adapter, other = {}) {
         if (!list[i].role) {
           list[i].role = 'member'
         }
+        if (!list[i].sex) {
+          list[i].sex = 'unknown'
+        }
       }
       ResponseData = list
     },


### PR DESCRIPTION
当从API获取用户数据时，如果用户没有设置性别信息，
则默认设置为'unknown'，以确保数据完整性。