### PR TITLE
Set default sex to 'unknown' in get_group_member_info

### DIFF
--- a/model/api.js
+++ b/model/api.js
@@ -549,6 +549,9 @@ async function getApiData (api, params = {}, name, uin, adapter, other = {}) {
       if (!ResponseData.nickname) {
         ResponseData.nickname = ResponseData.card || 'QQ用户'
       }
+      if (!ResponseData.sex) {
+        ResponseData.sex = 'unknown'
+      }
     },
     // 获取群成员列表
     get_group_member_list: async (params) => {


### PR DESCRIPTION
- 在最初启动的几分钟内，协议端不会返回sex字段