### PR TITLE
feat: 新增 OneBot 应用端 WebSocket 模式

### DIFF
--- a/apps/admin.js
+++ b/apps/admin.js
@@ -301,6 +301,11 @@ export class setting extends plugin {
     if (addWsMsg.length == 2) {
       for (const i of Config.servers) {
         if (i.name == addWsMsg[0]) {
+          if (Number(i.type) === 7) {
+            this.reply(`已经有连接名为${addWsMsg[0]}的OneBot应用端ws连接`)
+            this.finish('checkAddWs')
+            return
+          }
           if (Array.isArray(i.uin)) {
             if (i.uin.some(m => m == this.e.self_id)) {
               this.reply(`已经有连接名为${addWsMsg[0]}的连接并且已添加uin`)
@@ -443,10 +448,10 @@ export class setting extends plugin {
           break
       }
       // config.uin = Number(this.e.bot.uin || this.e.self_id) || String(this.e.bot.uin || this.e.self_id)
-      if (this.e.group) {
+      if (addWsMsg[1] !== '7' && this.e.group) {
         const seld_id = this.e.group?.bot?.uin || this.e.self_id
         config.uin = Number(seld_id) || String(seld_id)
-      } else if (this.e.friend) {
+      } else if (addWsMsg[1] !== '7' && this.e.friend) {
         const seld_id = this.e.friend?.bot?.uin || this.e.self_id
         config.uin = Number(seld_id) || String(seld_id)
       }
@@ -686,11 +691,12 @@ export class setting extends plugin {
       }
       let str = `连接名字: ${s.name}\n连接类型: ${s.type}\n当前状态: ${status}`
       if (!this.e.isGroup && this.e.isMaster) {
-        str += `\n连接地址: ${s.address}\nBot账号: ${s.uin}`
+        str += `\n连接地址: ${s.address}`
+        if (Number(s.type) !== 7) str += `\nBot账号: ${s.uin}`
         if (msg.length != 0) str = '\n---------------\n' + str
         msg.push(str)
       } else {
-        let uin = s.uin
+        let uin = Number(s.type) === 7 ? this.e.self_id : s.uin
         if (Array.isArray(uin)) {
           uin = this.e.user_id
         }

--- a/apps/admin.js
+++ b/apps/admin.js
@@ -227,7 +227,7 @@ export class setting extends plugin {
           '连接名字,连接类型\n',
           '---------------------------------\n',
           '连接名字: 用来区分每个连接\n',
-          '连接类型: 1:反向ws连接 2:正向ws连接 3:gscore连接 4:red连接 5:正向http 6:反向http'
+          '连接类型: 1:反向ws连接 2:正向ws连接 3:gscore连接 4:red连接 5:正向http 6:反向http 7:OneBot应用端ws'
         ])
         // await this.reply([
         //     '请一次性发送以下参数:\n',
@@ -396,6 +396,18 @@ export class setting extends plugin {
             // 'secret: 秘钥',
           ])
           break
+        case '7':
+          await this.reply([
+            '请继续发送以下参数,用逗号分割\n',
+            '---------------------------------\n',
+            '连接地址,重连间隔(默认5),最大重连次数(默认0),access-token(默认空)\n',
+            '---------------------------------\n',
+            '连接地址: OneBot实现端ws地址,比如wss://example.com/OneBotv11/123456\n',
+            '重连间隔: 断开连接时每隔多少秒进行重新连接\n',
+            '最大重连次数: 达到这个数之后不进行重连,为0时会不断重连\n',
+            'access-token: 访问秘钥'
+          ])
+          break
         default:
           await this.reply('格式有误,请检查后重新发送#ws添加连接')
           this.finish('checkAddWs')
@@ -413,6 +425,7 @@ export class setting extends plugin {
       switch (addWsMsg[1]) {
         case '1':
         case '3':
+        case '7':
           config.reconnectInterval = Number(addWsMsg[3]) || 5
           config.maxReconnectAttempts = Number(addWsMsg[4]) || 0
           config.accessToken = addWsMsg[5]

--- a/components/Client.js
+++ b/components/Client.js
@@ -5,6 +5,7 @@ import express from 'express'
 import http from 'http'
 import fetch from 'node-fetch'
 import url from 'url'
+import OneBotAppClientAdapter from '../model/onebot/AppClientAdapter.js'
 
 export default class Client {
   constructor ({ name, address, type, reconnectInterval, maxReconnectAttempts, accessToken, accessKey, uin = Bot.uin, closed = false, ...other }) {
@@ -97,6 +98,92 @@ export default class Client {
     })
     this.ws.on('error', (event) => {
       logger.error(`[ws-plugin] ${this.name} 连接失败\n${event}`)
+    })
+  }
+
+  createOneBotAppWs () {
+    const headers = {
+      'X-Self-ID': this.self_id,
+      'X-Client-Role': 'Universal',
+      'User-Agent': `ws-plugin/${Version.version}`
+    }
+    if (this.accessToken) headers.Authorization = this.accessKey + ' ' + this.accessToken
+
+    this.appAdapter = new OneBotAppClientAdapter().bindClient(this)
+    try {
+      this.ws = new WebSocket(this.address, { headers })
+    } catch (error) {
+      logger.error(`[ws-plugin] 出错了,可能是OneBot应用端ws地址填错了~\nws名字: ${this.name}\n地址: ${this.address}\n类型: 7`)
+      logger.error(error)
+      return
+    }
+
+    this.ws.sendMsg = data => {
+      if (this.ws?.readyState !== WebSocket.OPEN) {
+        throw new Error(`${this.name} OneBot应用端ws未连接`)
+      }
+      this.ws.send(JSON.stringify(data))
+    }
+
+    this.ws.on('open', async () => {
+      logger.mark(`[ws-plugin] ${this.name} OneBot应用端已连接`)
+      if (this.status == 3 && this.reconnectCount > 1 && Config.reconnectToMaster) {
+        await this.sendMasterMsg(`${this.name} 重连成功~`)
+      } else if (this.status == 0 && Config.firstconnectToMaster) {
+        await this.sendMasterMsg(`${this.name} 连接成功~`)
+      }
+      this.status = 1
+      this.reconnectCount = 1
+      const selfId = Number(this.self_id) || this.self_id
+      await this.appAdapter.connect({
+        self_id: selfId,
+        time: Math.floor(Date.now() / 1000)
+      }, this.ws).catch(error => {
+        logger.error(`[ws-plugin] ${this.name} OneBot应用端初始化失败`, error)
+      })
+    })
+
+    this.ws.on('message', event => {
+      const text = Buffer.isBuffer(event) ? event.toString() : String(event.data ?? event)
+      this.appAdapter.message(text, this.ws)
+    })
+
+    this.ws.on('close', async code => {
+      logger.warn(`[ws-plugin] ${this.name} OneBot应用端连接已关闭`)
+      if (this.status == 1 && Array.isArray(Bot?.uin) && Bot.uin.includes(this.self_id)) {
+        Bot.uin = Bot.uin.filter(i => i != this.self_id)
+      }
+      if (this.status == 1) {
+        delete Bot[this.self_id]
+        delete Bot[String(this.self_id)]
+        delete Bot[Number(this.self_id)]
+      }
+      if (Config.disconnectToMaster && this.reconnectCount == 1 && this.status == 1) {
+        await this.sendMasterMsg(`${this.name} 已断开连接...`)
+      } else if (Config.firstconnectToMaster && this.reconnectCount == 1 && this.status == 0) {
+        await this.sendMasterMsg(`${this.name} 连接失败...`)
+      }
+      this.status = 3
+      if (!this.stopReconnect && ((this.reconnectCount < this.maxReconnectAttempts) || this.maxReconnectAttempts <= 0)) {
+        if (code === 1005) {
+          logger.warn(`[ws-plugin] ${this.name} 连接异常,停止重连`)
+          this.status = 0
+        } else {
+          logger.warn(`[ws-plugin] ${this.name} 开始尝试重新连接第${this.reconnectCount}次`)
+          this.reconnectCount++
+          setTimeout(() => {
+            this.createOneBotAppWs()
+          }, this.reconnectInterval * 1000)
+        }
+      } else {
+        this.stopReconnect = false
+        this.status = 0
+        logger.warn(`[ws-plugin] ${this.name} 达到最大重连次数或关闭连接,停止重连`)
+      }
+    })
+
+    this.ws.on('error', event => {
+      logger.error(`[ws-plugin] ${this.name} OneBot应用端连接失败\n${event}`)
     })
   }
 

--- a/components/Client.js
+++ b/components/Client.js
@@ -103,7 +103,6 @@ export default class Client {
 
   createOneBotAppWs () {
     const headers = {
-      'X-Self-ID': this.self_id,
       'X-Client-Role': 'Universal',
       'User-Agent': `ws-plugin/${Version.version}`
     }
@@ -134,29 +133,29 @@ export default class Client {
       }
       this.status = 1
       this.reconnectCount = 1
-      const selfId = Number(this.self_id) || this.self_id
-      await this.appAdapter.connect({
-        self_id: selfId,
-        time: Math.floor(Date.now() / 1000)
-      }, this.ws).catch(error => {
+      await this.appAdapter.connectEndpoint(this.ws, this.getOneBotAppSelfIdHint()).catch(error => {
         logger.error(`[ws-plugin] ${this.name} OneBot应用端初始化失败`, error)
       })
     })
 
     this.ws.on('message', event => {
       const text = Buffer.isBuffer(event) ? event.toString() : String(event.data ?? event)
-      this.appAdapter.message(text, this.ws)
+      this.appAdapter.message(text, this.ws).catch(error => {
+        logger.error(`[ws-plugin] ${this.name} OneBot应用端消息处理失败`, error)
+      })
     })
 
     this.ws.on('close', async code => {
       logger.warn(`[ws-plugin] ${this.name} OneBot应用端连接已关闭`)
-      if (this.status == 1 && Array.isArray(Bot?.uin) && Bot.uin.includes(this.self_id)) {
-        Bot.uin = Bot.uin.filter(i => i != this.self_id)
+      const appSelfId = this.appSelfId
+      if (this.status == 1 && appSelfId && Array.isArray(Bot?.uin)) {
+        Bot.uin = Bot.uin.filter(i => String(i) !== String(appSelfId))
       }
-      if (this.status == 1) {
-        delete Bot[this.self_id]
-        delete Bot[String(this.self_id)]
-        delete Bot[Number(this.self_id)]
+      if (this.status == 1 && appSelfId) {
+        delete Bot[appSelfId]
+        delete Bot[String(appSelfId)]
+        delete Bot[Number(appSelfId)]
+        this.appSelfId = null
       }
       if (Config.disconnectToMaster && this.reconnectCount == 1 && this.status == 1) {
         await this.sendMasterMsg(`${this.name} 已断开连接...`)
@@ -185,6 +184,20 @@ export default class Client {
     this.ws.on('error', event => {
       logger.error(`[ws-plugin] ${this.name} OneBot应用端连接失败\n${event}`)
     })
+  }
+
+  getOneBotAppSelfIdHint () {
+    try {
+      const { pathname, searchParams } = new URL(this.address)
+      const querySelfId = searchParams.get('self_id') || searchParams.get('selfId')
+      if (querySelfId) return Number(querySelfId) || querySelfId
+      const tail = pathname.split('/').filter(Boolean).at(-1)
+      if (/^\d+$/.test(tail)) return Number(tail) || tail
+    } catch (error) {
+      const match = String(this.address).match(/(?:^|\/)(\d+)(?:\?|#|$)/)
+      if (match) return Number(match[1]) || match[1]
+    }
+    return null
   }
 
   createServer () {

--- a/components/WebSocket.js
+++ b/components/WebSocket.js
@@ -139,6 +139,9 @@ async function createWebSocket (data) {
       client.createHttpPost()
       sendSocketList.push(client)
       break
+    case 7:
+      client.createOneBotAppWs()
+      break
     default:
   }
 }

--- a/components/WebSocket.js
+++ b/components/WebSocket.js
@@ -61,6 +61,14 @@ async function createWebSocket (data) {
     delete data.close
   }
   data.rawName = data.rawName || data.name
+  if (Number(data.type) === 7) {
+    const client = new Client(data)
+    setAllSocketList(client)
+    if (data.address == 'ws_address') return
+    if (data.closed) return
+    client.createOneBotAppWs()
+    return
+  }
   if (Array.isArray(data.uin)) {
     for (const uin of data.uin) {
       const str = String(uin)

--- a/config/default_config/ws-config.yaml
+++ b/config/default_config/ws-config.yaml
@@ -47,6 +47,9 @@ onlyReplyAt:
 # name: 连接名字  请保证每个名字都不相同,否则会出问题
 # address: 连接地址
 # type: 连接类型
+#   1 反向ws: ws-plugin作为OneBot实现端，主动连接OneBot应用端
+#   2 正向ws: ws-plugin作为OneBot实现端，本地监听OneBot应用端连接
+#   7 OneBot应用端ws: ws-plugin作为OneBot应用端，主动连接OneBot实现端
 # reconnectInterval: 重连间隔 单位:秒
 # maxReconnectAttempts: 最大连接次数 0 为无限制
 # accessToken: 鉴权token

--- a/guoba.support.js
+++ b/guoba.support.js
@@ -67,6 +67,7 @@ export function supportGuoba() {
                         { label: 'red', value: 4 },
                         { label: '正向http', value: 5 },
                         { label: '反向http', value: 6 },
+                        { label: 'OneBot应用端ws', value: 7 },
                          ],
                   },
               },

--- a/model/onebot/AppClientAdapter.js
+++ b/model/onebot/AppClientAdapter.js
@@ -1,0 +1,1396 @@
+﻿import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+class OneBotAppClientAdapter {
+    id = "QQ"
+    name = "OneBotv11"
+    path = this.name
+    echo = new Map()
+    timeout = 60000
+    client = null
+    cacheGroupMember = false
+
+    makeLog (msg) {
+      return Bot.String(msg).replace(/base64:\/\/.*?(,|]|")/g, "base64://...$1")
+    }
+
+    sendApi (data, ws, action, params = {}) {
+      const echo = randomUUID()
+      const request = { action, params, echo }
+      ws.sendMsg(request)
+      const cache = Promise.withResolvers()
+      this.echo.set(echo, cache)
+      const timeout = setTimeout(() => {
+        cache.reject(Bot.makeError("请求超时", request, { timeout: this.timeout }))
+        Bot.makeLog("error", ["请求超时", request], data.self_id)
+        ws.terminate()
+      }, this.timeout)
+
+      return cache.promise
+        .then(data => {
+          if (data.retcode !== 0 && data.retcode !== 1)
+          { throw Bot.makeError(data.msg || data.wording, request, { error: data }) }
+          return data.data
+            ? new Proxy(data, {
+              get: (target, prop) => target.data[prop] ?? target[prop]
+            })
+            : data
+        })
+        .finally(() => {
+          clearTimeout(timeout)
+          this.echo.delete(echo)
+        })
+    }
+
+    async makeFile (file, opts) {
+      file = await Bot.Buffer(file, {
+        http: true,
+        size: 10485760,
+        ...opts
+      })
+      if (Buffer.isBuffer(file)) return `base64://${file.toString("base64")}`
+      return file
+    }
+
+    async makeMsg (msg) {
+      if (!Array.isArray(msg)) msg = [msg]
+      const msgs = []
+      const forward = []
+      for (let i of msg) {
+        if (typeof i !== "object") i = { type: "text", data: { text: i } }
+        else if (!i.data) i = { type: i.type, data: { ...i, type: undefined } }
+
+        switch (i.type) {
+          case "at":
+            i.data.qq = String(i.data.qq)
+            break
+          case "reply":
+            i.data.id = String(i.data.id)
+            break
+          case "button":
+            continue
+          case "node":
+            forward.push(...i.data)
+            continue
+          case "raw":
+            i = i.data
+            break
+        }
+
+        if (i.data.file) i.data.file = await this.makeFile(i.data.file)
+
+        msgs.push(i)
+      }
+      return [msgs, forward]
+    }
+
+    async sendMsg (msg, send, sendForwardMsg) {
+      const [message, forward] = await this.makeMsg(msg)
+      const ret = []
+
+      if (forward.length) {
+        const data = await sendForwardMsg(forward)
+        if (Array.isArray(data)) ret.push(...data)
+        else ret.push(data)
+      }
+
+      if (message.length) ret.push(await send(message))
+      if (ret.length === 1) return ret[0]
+
+      const message_id = []
+      for (const i of ret) if (i?.message_id) message_id.push(i.message_id)
+      return { data: ret, message_id }
+    }
+
+    sendFriendMsg (data, msg) {
+      return this.sendMsg(
+        msg,
+        message => {
+          Bot.makeLog(
+            "info",
+            `发送好友消息：${this.makeLog(message)}`,
+            `${data.self_id} => ${data.user_id}`,
+            true
+          )
+          return data.bot.sendApi("send_msg", {
+            user_id: data.user_id,
+            message
+          })
+        },
+        msg => this.sendFriendForwardMsg(data, msg)
+      )
+    }
+
+    sendGroupMsg (data, msg) {
+      return this.sendMsg(
+        msg,
+        message => {
+          Bot.makeLog(
+            "info",
+            `发送群消息：${this.makeLog(message)}`,
+            `${data.self_id} => ${data.group_id}`,
+            true
+          )
+          return data.bot.sendApi("send_msg", {
+            group_id: data.group_id,
+            message
+          })
+        },
+        msg => this.sendGroupForwardMsg(data, msg)
+      )
+    }
+
+    sendGuildMsg (data, msg) {
+      return this.sendMsg(
+        msg,
+        message => {
+          Bot.makeLog(
+            "info",
+            `发送频道消息：${this.makeLog(message)}`,
+            `${data.self_id}] => ${data.guild_id}-${data.channel_id}`,
+            true
+          )
+          return data.bot.sendApi("send_guild_channel_msg", {
+            guild_id: data.guild_id,
+            channel_id: data.channel_id,
+            message
+          })
+        },
+        msg => Bot.sendForwardMsg(msg => this.sendGuildMsg(data, msg), msg)
+      )
+    }
+
+    async recallMsg (data, message_id) {
+      Bot.makeLog("info", `撤回消息：${message_id}`, data.self_id)
+      if (!Array.isArray(message_id)) message_id = [message_id]
+      const msgs = []
+      for (const i of message_id)
+      { msgs.push(await data.bot.sendApi("delete_msg", { message_id: i }).catch(i => i)) }
+      return msgs
+    }
+
+    parseMsg (msg) {
+      const array = []
+      for (const i of Array.isArray(msg) ? msg : [msg])
+      { if (typeof i === "object") array.push({ ...i.data, type: i.type })
+      else array.push({ type: "text", text: String(i) }) }
+      return array
+    }
+
+    async getMsg (data, message_id) {
+      const msg = await data.bot.sendApi("get_msg", { message_id })
+      if (msg?.message) msg.message = this.parseMsg(msg.message)
+      return msg
+    }
+
+    async getFriendMsgHistory (data, message_seq, count, reverseOrder = true) {
+      const msgs = (
+        await data.bot.sendApi("get_friend_msg_history", {
+          user_id: data.user_id,
+          message_seq,
+          count,
+          reverseOrder
+        })
+      ).messages
+
+      for (const i of Array.isArray(msgs) ? msgs : [msgs])
+      { if (i?.message) i.message = this.parseMsg(i.message) }
+      return msgs
+    }
+
+    async getGroupMsgHistory (data, message_seq, count, reverseOrder = true) {
+      const msgs = (
+        await data.bot.sendApi("get_group_msg_history", {
+          group_id: data.group_id,
+          message_seq,
+          count,
+          reverseOrder
+        })
+      ).messages
+
+      for (const i of Array.isArray(msgs) ? msgs : [msgs])
+      { if (i?.message) i.message = this.parseMsg(i.message) }
+      return msgs
+    }
+
+    async getForwardMsg (data, message_id) {
+      const msgs = (
+        await data.bot.sendApi("get_forward_msg", {
+          message_id
+        })
+      ).messages
+
+      for (const i of Array.isArray(msgs) ? msgs : [msgs])
+      { if (i?.message) i.message = this.parseMsg(i.message || i.content) }
+      return msgs
+    }
+
+    async makeForwardMsg (msg) {
+      const msgs = []
+      for (const i of msg) {
+        const [content, forward] = await this.makeMsg(i.message)
+        if (forward.length) msgs.push(...(await this.makeForwardMsg(forward)))
+        if (content.length)
+        { msgs.push({
+          type: "node",
+          data: {
+            name: i.nickname || "匿名消息",
+            uin: String(Number(i.user_id) || 80000000),
+            content,
+            time: i.time
+          }
+        }) }
+      }
+      return msgs
+    }
+
+    async sendFriendForwardMsg (data, msg) {
+      Bot.makeLog(
+        "info",
+        `发送好友转发消息：${this.makeLog(msg)}`,
+        `${data.self_id} => ${data.user_id}`,
+        true
+      )
+      return data.bot.sendApi("send_private_forward_msg", {
+        user_id: data.user_id,
+        messages: await this.makeForwardMsg(msg)
+      })
+    }
+
+    async sendGroupForwardMsg (data, msg) {
+      Bot.makeLog(
+        "info",
+        `发送群转发消息：${this.makeLog(msg)}`,
+        `${data.self_id} => ${data.group_id}`,
+        true
+      )
+      return data.bot.sendApi("send_group_forward_msg", {
+        group_id: data.group_id,
+        messages: await this.makeForwardMsg(msg)
+      })
+    }
+
+    async getFriendArray (data) {
+      const dataOrArray = await data.bot.sendApi("get_friend_list")
+      return dataOrArray.friends || dataOrArray.data || dataOrArray || []
+    }
+
+    async getFriendList (data) {
+      const array = []
+      for (const { user_id } of await this.getFriendArray(data)) array.push(user_id)
+      return array
+    }
+
+    async getFriendMap (data) {
+      const map = new Map()
+      for (const i of await this.getFriendArray(data)) map.set(i.user_id, i)
+      data.bot.fl = map
+      return map
+    }
+
+    async getFriendInfo (data) {
+      const info = (
+        await data.bot.sendApi("get_stranger_info", {
+          user_id: data.user_id
+        })
+      ).data
+      data.bot.fl.set(data.user_id, info)
+      return info
+    }
+
+    async getGroupArray (data) {
+      const dataOrArray = await data.bot.sendApi("get_group_list")
+      const array = dataOrArray.groups || dataOrArray.data || dataOrArray || []
+      return array
+    }
+
+    async getGroupList (data) {
+      const array = []
+      for (const { group_id } of await this.getGroupArray(data)) array.push(group_id)
+      return array
+    }
+
+    async getGroupMap (data) {
+      const map = new Map()
+      for (const i of await this.getGroupArray(data)) map.set(i.group_id, i)
+      data.bot.gl = map
+      return map
+    }
+
+    async getGroupInfo (data) {
+      const info = (
+        await data.bot.sendApi("get_group_info", {
+          group_id: data.group_id
+        })
+      ).data
+      data.bot.gl.set(data.group_id, info)
+      return info
+    }
+
+    async getMemberArray (data) {
+      const dataOrArray = await data.bot.sendApi("get_group_member_list", {
+        group_id: data.group_id
+      })
+      return dataOrArray.members || dataOrArray.data || dataOrArray || []
+    }
+
+    async getMemberList (data) {
+      const array = []
+      for (const { user_id } of await this.getMemberArray(data)) array.push(user_id)
+      return array
+    }
+
+    async getMemberMap (data) {
+      const map = new Map()
+      for (const i of await this.getMemberArray(data)) map.set(i.user_id, i)
+      data.bot.gml.set(data.group_id, map)
+      return map
+    }
+
+    async getGroupMemberMap (data) {
+      if (!this.cacheGroupMember) return this.getGroupMap(data)
+      for (const [group_id, group] of await this.getGroupMap(data)) {
+        if (group.guild) continue
+        await this.getMemberMap({ ...data, group_id })
+      }
+    }
+
+    async getMemberInfo (data) {
+      const info = (
+        await data.bot.sendApi("get_group_member_info", {
+          group_id: data.group_id,
+          user_id: data.user_id
+        })
+      ).data
+      let gml = data.bot.gml.get(data.group_id)
+      if (!gml) {
+        gml = new Map()
+        data.bot.gml.set(data.group_id, gml)
+      }
+      gml.set(data.user_id, info)
+      return info
+    }
+
+    async getGuildArray (data) {
+      return []
+    }
+
+    getGuildInfo (data) {
+      return data.bot.sendApi("get_guild_meta_by_guest", {
+        guild_id: data.guild_id
+      })
+    }
+
+    async getGuildChannelArray (data) {
+      return (
+        (
+          await data.bot.sendApi("get_guild_channel_list", {
+            guild_id: data.guild_id
+          })
+        ).data || []
+      )
+    }
+
+    async getGuildChannelMap (data) {
+      const map = new Map()
+      for (const i of await this.getGuildChannelArray(data)) map.set(i.channel_id, i)
+      return map
+    }
+
+    async getGuildMemberArray (data) {
+      const array = []
+      let next_token = ""
+      while (true) {
+        const list = (
+          await data.bot.sendApi("get_guild_member_list", {
+            guild_id: data.guild_id,
+            next_token
+          })
+        ).data
+        if (!list) break
+
+        for (const i of list.members)
+        { array.push({
+          ...i,
+          user_id: i.tiny_id
+        }) }
+        if (list.finished) break
+        next_token = list.next_token
+      }
+      return array
+    }
+
+    async getGuildMemberList (data) {
+      const array = []
+      for (const { user_id } of await this.getGuildMemberArray(data)) array.push(user_id)
+      return array.push
+    }
+
+    async getGuildMemberMap (data) {
+      const map = new Map()
+      for (const i of await this.getGuildMemberArray(data)) map.set(i.user_id, i)
+      data.bot.gml.set(data.group_id, map)
+      return map
+    }
+
+    getGuildMemberInfo (data) {
+      return data.bot.sendApi("get_guild_member_profile", {
+        guild_id: data.guild_id,
+        user_id: data.user_id
+      })
+    }
+
+    setProfile (data, profile) {
+      Bot.makeLog("info", `设置资料：${Bot.String(profile)}`, data.self_id)
+      return data.bot.sendApi("set_qq_profile", profile)
+    }
+
+    async setAvatar (data, file) {
+      Bot.makeLog("info", `设置头像：${file}`, data.self_id)
+      return data.bot.sendApi("set_qq_avatar", {
+        file: await this.makeFile(file)
+      })
+    }
+
+    sendLike (data, times) {
+      Bot.makeLog("info", `点赞：${times}次`, `${data.self_id} => ${data.user_id}`, true)
+      return data.bot.sendApi("send_like", {
+        user_id: data.user_id,
+        times
+      })
+    }
+
+    setGroupName (data, group_name) {
+      Bot.makeLog("info", `设置群名：${group_name}`, `${data.self_id} => ${data.group_id}`, true)
+      return data.bot.sendApi("set_group_name", {
+        group_id: data.group_id,
+        group_name
+      })
+    }
+
+    async setGroupAvatar (data, file) {
+      Bot.makeLog("info", `设置群头像：${file}`, `${data.self_id} => ${data.group_id}`, true)
+      return data.bot.sendApi("set_group_portrait", {
+        group_id: data.group_id,
+        file: await this.makeFile(file)
+      })
+    }
+
+    setGroupAdmin (data, user_id, enable) {
+      Bot.makeLog(
+        "info",
+        `${enable ? "设置" : "取消"}群管理员：${user_id}`,
+        `${data.self_id} => ${data.group_id}`,
+        true
+      )
+      return data.bot.sendApi("set_group_admin", {
+        group_id: data.group_id,
+        user_id,
+        enable
+      })
+    }
+
+    setGroupCard (data, user_id, card) {
+      Bot.makeLog(
+        "info",
+        `设置群名片：${card}`,
+        `${data.self_id} => ${data.group_id}, ${user_id}`,
+        true
+      )
+      return data.bot.sendApi("set_group_card", {
+        group_id: data.group_id,
+        user_id,
+        card
+      })
+    }
+
+    setGroupTitle (data, user_id, special_title, duration) {
+      Bot.makeLog(
+        "info",
+        `设置群头衔：${special_title} ${duration}`,
+        `${data.self_id} => ${data.group_id}, ${user_id}`,
+        true
+      )
+      return data.bot.sendApi("set_group_special_title", {
+        group_id: data.group_id,
+        user_id,
+        special_title,
+        duration
+      })
+    }
+
+    sendGroupSign (data) {
+      Bot.makeLog("info", "群打卡", `${data.self_id} => ${data.group_id}`, true)
+      return data.bot.sendApi("send_group_sign", {
+        group_id: data.group_id
+      })
+    }
+
+    setGroupBan (data, user_id, duration) {
+      Bot.makeLog(
+        "info",
+        `禁言群成员：${duration}秒`,
+        `${data.self_id} => ${data.group_id}, ${user_id}`,
+        true
+      )
+      return data.bot.sendApi("set_group_ban", {
+        group_id: data.group_id,
+        user_id,
+        duration
+      })
+    }
+
+    setGroupWholeKick (data, enable) {
+      Bot.makeLog(
+        "info",
+        `${enable ? "开启" : "关闭"}全员禁言`,
+        `${data.self_id} => ${data.group_id}`,
+        true
+      )
+      return data.bot.sendApi("set_group_whole_ban", {
+        group_id: data.group_id,
+        enable
+      })
+    }
+
+    setGroupKick (data, user_id, reject_add_request) {
+      Bot.makeLog(
+        "info",
+        `踢出群成员${reject_add_request ? "拒绝再次加群" : ""}`,
+        `${data.self_id} => ${data.group_id}, ${user_id}`,
+        true
+      )
+      return data.bot.sendApi("set_group_kick", {
+        group_id: data.group_id,
+        user_id,
+        reject_add_request
+      })
+    }
+
+    setGroupLeave (data, is_dismiss) {
+      Bot.makeLog("info", is_dismiss ? "解散" : "退群", `${data.self_id} => ${data.group_id}`, true)
+      return data.bot.sendApi("set_group_leave", {
+        group_id: data.group_id,
+        is_dismiss
+      })
+    }
+
+    downloadFile (data, url, thread_count, headers) {
+      return data.bot.sendApi("download_file", {
+        url,
+        thread_count,
+        headers
+      })
+    }
+
+    async sendFriendFile (data, file, name = path.basename(file)) {
+      Bot.makeLog(
+        "info",
+        `发送好友文件：${name}(${file})`,
+        `${data.self_id} => ${data.user_id}`,
+        true
+      )
+      return data.bot.sendApi("upload_private_file", {
+        user_id: data.user_id,
+        file: (await this.makeFile(file, { file: true })).replace("file://", ""),
+        name
+      })
+    }
+
+    async sendGroupFile (data, file, folder, name = path.basename(file)) {
+      Bot.makeLog(
+        "info",
+        `发送群文件：${folder || ""}/${name}(${file})`,
+        `${data.self_id} => ${data.group_id}`,
+        true
+      )
+      return data.bot.sendApi("upload_group_file", {
+        group_id: data.group_id,
+        folder,
+        file: (await this.makeFile(file, { file: true })).replace("file://", ""),
+        name
+      })
+    }
+
+    deleteGroupFile (data, file_id, busid) {
+      Bot.makeLog(
+        "info",
+        `删除群文件：${file_id}(${busid})`,
+        `${data.self_id} => ${data.group_id}`,
+        true
+      )
+      return data.bot.sendApi("delete_group_file", {
+        group_id: data.group_id,
+        file_id,
+        busid
+      })
+    }
+
+    createGroupFileFolder (data, name) {
+      Bot.makeLog("info", `创建群文件夹：${name}`, `${data.self_id} => ${data.group_id}`, true)
+      return data.bot.sendApi("create_group_file_folder", {
+        group_id: data.group_id,
+        name
+      })
+    }
+
+    getGroupFileSystemInfo (data) {
+      return data.bot.sendApi("get_group_file_system_info", {
+        group_id: data.group_id
+      })
+    }
+
+    getGroupFiles (data, folder_id) {
+      if (folder_id)
+      { return data.bot.sendApi("get_group_files_by_folder", {
+        group_id: data.group_id,
+        folder_id
+      }) }
+      return data.bot.sendApi("get_group_root_files", {
+        group_id: data.group_id
+      })
+    }
+
+    getGroupFileUrl (data, file_id, busid) {
+      return data.bot.sendApi("get_group_file_url", {
+        group_id: data.group_id,
+        file_id,
+        busid
+      })
+    }
+
+    getGroupFs (data) {
+      return {
+        upload: this.sendGroupFile.bind(this, data),
+        rm: this.deleteGroupFile.bind(this, data),
+        mkdir: this.createGroupFileFolder.bind(this, data),
+        df: this.getGroupFileSystemInfo.bind(this, data),
+        ls: this.getGroupFiles.bind(this, data),
+        download: this.getGroupFileUrl.bind(this, data)
+      }
+    }
+
+    deleteFriend (data) {
+      Bot.makeLog("info", "删除好友", `${data.self_id} => ${data.user_id}`, true)
+      return data.bot
+        .sendApi("delete_friend", { user_id: data.user_id })
+        .finally(this.getFriendMap.bind(this, data))
+    }
+
+    setFriendAddRequest (data, flag, approve, remark) {
+      return data.bot.sendApi("set_friend_add_request", {
+        flag,
+        approve,
+        remark
+      })
+    }
+
+    setGroupAddRequest (data, flag, approve, reason, sub_type = "add") {
+      return data.bot.sendApi("set_group_add_request", {
+        flag,
+        sub_type,
+        approve,
+        reason
+      })
+    }
+
+    getGroupHonorInfo (data) {
+      return data.bot.sendApi("get_group_honor_info", { group_id: data.group_id })
+    }
+
+    getEssenceMsg (data) {
+      return data.bot.sendApi("get_essence_msg_list", { group_id: data.group_id })
+    }
+
+    setEssenceMsg (data, message_id) {
+      return data.bot.sendApi("set_essence_msg", { message_id })
+    }
+
+    deleteEssenceMsg (data, message_id) {
+      return data.bot.sendApi("delete_essence_msg", { message_id })
+    }
+
+    pickFriend (data, user_id) {
+      const i = {
+        ...data.bot.fl.get(user_id),
+        ...data,
+        user_id
+      }
+      return {
+        ...i,
+        sendMsg: this.sendFriendMsg.bind(this, i),
+        getMsg: this.getMsg.bind(this, i),
+        recallMsg: this.recallMsg.bind(this, i),
+        getForwardMsg: this.getForwardMsg.bind(this, i),
+        sendForwardMsg: this.sendFriendForwardMsg.bind(this, i),
+        sendFile: this.sendFriendFile.bind(this, i),
+        getInfo: this.getFriendInfo.bind(this, i),
+        getAvatarUrl () {
+          return this.avatar || `https://q.qlogo.cn/g?b=qq&s=0&nk=${user_id}`
+        },
+        getChatHistory: this.getFriendMsgHistory.bind(this, i),
+        thumbUp: this.sendLike.bind(this, i),
+        delete: this.deleteFriend.bind(this, i)
+      }
+    }
+
+    pickMember (data, group_id, user_id) {
+      if (typeof group_id === "string" && group_id.match("-")) {
+        const guild_id = group_id.split("-")
+        const i = {
+          ...data,
+          guild_id: guild_id[0],
+          channel_id: guild_id[1],
+          user_id
+        }
+        return {
+          ...this.pickGroup(i, group_id),
+          ...i,
+          getInfo: this.getGuildMemberInfo.bind(this, i),
+          getAvatarUrl: async () => (await this.getGuildMemberInfo(i)).avatar_url
+        }
+      }
+
+      const i = {
+        ...data.bot.gml.get(group_id)?.get(user_id),
+        ...data,
+        group_id,
+        user_id
+      }
+      return {
+        ...this.pickFriend(i, user_id),
+        ...i,
+        getInfo: this.getMemberInfo.bind(this, i),
+        getAvatarUrl () {
+          return this.avatar || `https://q.qlogo.cn/g?b=qq&s=0&nk=${user_id}`
+        },
+        poke: this.sendGroupMsg.bind(this, i, { type: "poke", qq: user_id }),
+        mute: this.setGroupBan.bind(this, i, user_id),
+        kick: this.setGroupKick.bind(this, i, user_id),
+        get is_friend () {
+          return data.bot.fl.has(user_id)
+        },
+        get is_owner () {
+          return this.role === "owner"
+        },
+        get is_admin () {
+          return this.role === "admin" || this.is_owner
+        }
+      }
+    }
+
+    pickGroup (data, group_id) {
+      if (typeof group_id === "string" && group_id.match("-")) {
+        const guild_id = group_id.split("-")
+        const i = {
+          ...data.bot.gl.get(group_id),
+          ...data,
+          guild_id: guild_id[0],
+          channel_id: guild_id[1]
+        }
+        return {
+          ...i,
+          sendMsg: this.sendGuildMsg.bind(this, i),
+          getMsg: this.getMsg.bind(this, i),
+          recallMsg: this.recallMsg.bind(this, i),
+          getForwardMsg: this.getForwardMsg.bind(this, i),
+          getInfo: this.getGuildInfo.bind(this, i),
+          getChannelArray: this.getGuildChannelArray.bind(this, i),
+          getChannelList: this.getGuildChannelList.bind(this, i),
+          getChannelMap: this.getGuildChannelMap.bind(this, i),
+          getMemberArray: this.getGuildMemberArray.bind(this, i),
+          getMemberList: this.getGuildMemberList.bind(this, i),
+          getMemberMap: this.getGuildMemberMap.bind(this, i),
+          pickMember: this.pickMember.bind(this, i)
+        }
+      }
+
+      const i = {
+        ...data.bot.gl.get(group_id),
+        ...data,
+        group_id
+      }
+      return {
+        ...i,
+        sendMsg: this.sendGroupMsg.bind(this, i),
+        getMsg: this.getMsg.bind(this, i),
+        recallMsg: this.recallMsg.bind(this, i),
+        getForwardMsg: this.getForwardMsg.bind(this, i),
+        sendForwardMsg: this.sendGroupForwardMsg.bind(this, i),
+        sendFile: (file, name) => this.sendGroupFile(i, file, undefined, name),
+        getInfo: this.getGroupInfo.bind(this, i),
+        getAvatarUrl () {
+          return this.avatar || `https://p.qlogo.cn/gh/${group_id}/${group_id}/0`
+        },
+        getChatHistory: this.getGroupMsgHistory.bind(this, i),
+        getHonorInfo: this.getGroupHonorInfo.bind(this, i),
+        getEssence: this.getEssenceMsg.bind(this, i),
+        getMemberArray: this.getMemberArray.bind(this, i),
+        getMemberList: this.getMemberList.bind(this, i),
+        getMemberMap: this.getMemberMap.bind(this, i),
+        pickMember: this.pickMember.bind(this, i, group_id),
+        pokeMember: qq => this.sendGroupMsg(i, { type: "poke", qq }),
+        setName: this.setGroupName.bind(this, i),
+        setAvatar: this.setGroupAvatar.bind(this, i),
+        setAdmin: this.setGroupAdmin.bind(this, i),
+        setCard: this.setGroupCard.bind(this, i),
+        setTitle: this.setGroupTitle.bind(this, i),
+        sign: this.sendGroupSign.bind(this, i),
+        muteMember: this.setGroupBan.bind(this, i),
+        muteAll: this.setGroupWholeKick.bind(this, i),
+        kickMember: this.setGroupKick.bind(this, i),
+        quit: this.setGroupLeave.bind(this, i),
+        fs: this.getGroupFs(i),
+        get is_owner () {
+          return data.bot.gml.get(group_id)?.get(data.self_id)?.role === "owner"
+        },
+        get is_admin () {
+          return data.bot.gml.get(group_id)?.get(data.self_id)?.role === "admin" || this.is_owner
+        }
+      }
+    }
+
+    async connect (data, ws) {
+      if (Bot[data.self_id]) {
+        data.bot = Bot[data.self_id]
+        return
+      }
+      Bot[data.self_id] = {
+        adapter: this,
+        ws,
+        sendApi: this.sendApi.bind(this, data, ws),
+        stat: {
+          start_time: data.time,
+          stat: {},
+          get lost_pkt_cnt () {
+            return this.stat.packet_lost
+          },
+          get lost_times () {
+            return this.stat.lost_times
+          },
+          get recv_msg_cnt () {
+            return this.stat.message_received
+          },
+          get recv_pkt_cnt () {
+            return this.stat.packet_received
+          },
+          get sent_msg_cnt () {
+            return this.stat.message_sent
+          },
+          get sent_pkt_cnt () {
+            return this.stat.packet_sent
+          }
+        },
+        model: "TRSS Yunzai ",
+
+        info: {},
+        get uin () {
+          return this.info.user_id
+        },
+        get nickname () {
+          return this.info.nickname
+        },
+        get avatar () {
+          return `https://q.qlogo.cn/g?b=qq&s=0&nk=${this.uin}`
+        },
+
+        setProfile: this.setProfile.bind(this, data),
+        setNickname: nickname => this.setProfile(data, { nickname }),
+        setAvatar: this.setAvatar.bind(this, data),
+
+        pickFriend: this.pickFriend.bind(this, data),
+        get pickUser () {
+          return this.pickFriend
+        },
+        getFriendArray: this.getFriendArray.bind(this, data),
+        getFriendList: this.getFriendList.bind(this, data),
+        getFriendMap: this.getFriendMap.bind(this, data),
+        fl: new Map(),
+
+        pickMember: this.pickMember.bind(this, data),
+        pickGroup: this.pickGroup.bind(this, data),
+        getGroupArray: this.getGroupArray.bind(this, data),
+        getGroupList: this.getGroupList.bind(this, data),
+        getGroupMap: this.getGroupMap.bind(this, data),
+        getGroupMemberMap: this.getGroupMemberMap.bind(this, data),
+        gl: new Map(),
+        gml: new Map(),
+
+        request_list: [],
+        getSystemMsg () {
+          return this.request_list
+        },
+        setFriendAddRequest: this.setFriendAddRequest.bind(this, data),
+        setGroupAddRequest: this.setGroupAddRequest.bind(this, data),
+
+        setEssenceMessage: this.setEssenceMsg.bind(this, data),
+        removeEssenceMessage: this.deleteEssenceMsg.bind(this, data),
+
+        cookies: {},
+        getCookies (domain) {
+          return this.cookies[domain]
+        },
+        getCsrfToken () {
+          return this.bkn
+        }
+      }
+      data.bot = Bot[data.self_id]
+
+      if (Array.isArray(Bot.uin)) {
+        if (!Bot.uin.includes(data.self_id)) Bot.uin.push(data.self_id)
+      } else if (Bot.uin !== data.self_id) {
+        Bot.uin = [Bot.uin, data.self_id].filter(Boolean)
+      }
+
+      data.bot.info = await data.bot.sendApi("get_login_info").catch(() => ({
+        user_id: data.self_id,
+        nickname: data.self_id
+      }))
+      data.bot.clients = []
+      data.bot.version = {
+        ...((await data.bot.sendApi("get_version_info").catch(() => ({}))) || {}),
+        id: this.id,
+        name: this.name,
+        get version () {
+          return this.app_full_name || `${this.app_name} v${this.app_version}`
+        }
+      }
+
+      data.bot.getFriendMap().catch(err => {
+        Bot.makeLog("warn", ["获取好友列表失败", err], data.self_id)
+      })
+      data.bot.getGroupMap().catch(err => {
+        Bot.makeLog("warn", ["获取群列表失败", err], data.self_id)
+      })
+
+      Bot.makeLog(
+        "mark",
+        `${this.name}(${this.id}) ${data.bot.version.version} 已连接`,
+        data.self_id
+      )
+      Bot.em(`connect.${data.self_id}`, data)
+    }
+
+    makeMessage (data) {
+      data.message = this.parseMsg(data.message)
+      switch (data.message_type) {
+        case "private": {
+          const name =
+            data.sender.card || data.sender.nickname || data.bot.fl.get(data.user_id)?.nickname
+          Bot.makeLog(
+            "info",
+            `好友消息：${name ? `[${name}] ` : ""}${data.raw_message}`,
+            `${data.self_id} <= ${data.user_id}`,
+            true
+          )
+          break
+        }
+        case "group": {
+          const group_name = data.group_name || data.bot.gl.get(data.group_id)?.group_name
+          let user_name = data.sender.card || data.sender.nickname
+          if (!user_name) {
+            const user =
+              data.bot.gml.get(data.group_id)?.get(data.user_id) || data.bot.fl.get(data.user_id)
+            if (user) user_name = user?.card || user?.nickname
+          }
+          Bot.makeLog(
+            "info",
+            `群消息：${user_name ? `[${group_name ? `${group_name}, ` : ""}${user_name}] ` : ""}${data.raw_message}`,
+            `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+            true
+          )
+          break
+        }
+        case "guild":
+          data.message_type = "group"
+          data.group_id = `${data.guild_id}-${data.channel_id}`
+          Bot.makeLog(
+            "info",
+            `频道消息：[${data.sender.nickname}] ${Bot.String(data.message)}`,
+            `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+            true
+          )
+          Object.defineProperty(data, "friend", {
+            get () {
+              return this.member || {}
+            }
+          })
+          break
+        default:
+          Bot.makeLog("warn", `未知消息：${logger.magenta(data.raw)}`, data.self_id)
+      }
+
+      Bot.em(`${data.post_type}.${data.message_type}.${data.sub_type}`, data)
+    }
+
+    async makeNotice (data) {
+      switch (data.notice_type) {
+        case "friend_recall":
+          Bot.makeLog(
+            "info",
+            `好友消息撤回：${data.message_id}`,
+            `${data.self_id} <= ${data.user_id}`,
+            true
+          )
+          break
+        case "group_recall":
+          Bot.makeLog(
+            "info",
+            `群消息撤回：${data.operator_id} => ${data.user_id} ${data.message_id}`,
+            `${data.self_id} <= ${data.group_id}`,
+            true
+          )
+          break
+        case "group_increase": {
+          Bot.makeLog(
+            "info",
+            `群成员增加：${data.operator_id} => ${data.user_id} ${data.sub_type}`,
+            `${data.self_id} <= ${data.group_id}`,
+            true
+          )
+          const group = data.bot.pickGroup(data.group_id)
+          group.getInfo()
+          if (data.user_id === data.self_id && this.cacheGroupMember) group.getMemberMap()
+          else group.pickMember(data.user_id).getInfo()
+          break
+        }
+        case "group_decrease": {
+          Bot.makeLog(
+            "info",
+            `群成员减少：${data.operator_id} => ${data.user_id} ${data.sub_type}`,
+            `${data.self_id} <= ${data.group_id}`,
+            true
+          )
+          if (data.user_id === data.self_id) {
+            data.bot.gl.delete(data.group_id)
+            data.bot.gml.delete(data.group_id)
+          } else {
+            data.bot.pickGroup(data.group_id).getInfo()
+            data.bot.gml.get(data.group_id)?.delete(data.user_id)
+          }
+          break
+        }
+        case "group_admin":
+          Bot.makeLog(
+            "info",
+            `群管理员变动：${data.sub_type}`,
+            `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+            true
+          )
+          data.set = data.sub_type === "set"
+          data.bot.pickMember(data.group_id, data.user_id).getInfo()
+          break
+        case "group_upload":
+          Bot.makeLog(
+            "info",
+            `群文件上传：${Bot.String(data.file)}`,
+            `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+            true
+          )
+          Bot.em("message.group.normal", {
+            ...data,
+            post_type: "message",
+            message_type: "group",
+            sub_type: "normal",
+            message: [{ ...data.file, type: "file" }],
+            raw_message: `[文件：${data.file.name}]`
+          })
+          break
+        case "group_ban":
+          Bot.makeLog(
+            "info",
+            `群禁言：${data.operator_id} => ${data.user_id} ${data.sub_type} ${data.duration}秒`,
+            `${data.self_id} <= ${data.group_id}`,
+            true
+          )
+          data.bot.pickMember(data.group_id, data.user_id).getInfo()
+          break
+        case "group_msg_emoji_like":
+          Bot.makeLog(
+            "info",
+            [`群消息回应：${data.message_id}`, data.likes],
+            `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+            true
+          )
+          break
+        case "friend_add":
+          Bot.makeLog("info", "好友添加", `${data.self_id} <= ${data.user_id}`, true)
+          data.bot.pickFriend(data.user_id).getInfo()
+          break
+        case "notify":
+          if (data.group_id) data.notice_type = "group"
+          else data.notice_type = "friend"
+          data.user_id ??= data.operator_id || data.target_id
+          switch (data.sub_type) {
+            case "poke":
+              data.operator_id = data.user_id
+              if (data.group_id)
+              { Bot.makeLog(
+                "info",
+                  `群戳一戳：${data.operator_id} => ${data.target_id}`,
+                  `${data.self_id} <= ${data.group_id}`,
+                  true
+              ) }
+              else
+              { Bot.makeLog(
+                "info",
+                  `好友戳一戳：${data.operator_id} => ${data.target_id}`,
+                  data.self_id
+              ) }
+              break
+            case "honor":
+              Bot.makeLog(
+                "info",
+                `群荣誉：${data.honor_type}`,
+                `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+                true
+              )
+              data.bot.pickMember(data.group_id, data.user_id).getInfo()
+              break
+            case "title":
+              Bot.makeLog(
+                "info",
+                `群头衔：${data.title}`,
+                `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+                true
+              )
+              data.bot.pickMember(data.group_id, data.user_id).getInfo()
+              break
+            case "group_name":
+              Bot.makeLog(
+                "info",
+                `群名更改：${data.name_new}`,
+                `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+                true
+              )
+              data.bot.pickGroup(data.group_id).getInfo()
+              break
+            case "input_status":
+              data.post_type = "internal"
+              data.notice_type = "input"
+              data.end ??= data.event_type !== 1
+              data.message ||= data.status_text || `对方${data.end ? "结束" : "正在"}输入...`
+              Bot.makeLog("info", data.message, `${data.self_id} <= ${data.user_id}`, true)
+              break
+            case "profile_like":
+              Bot.makeLog(
+                "info",
+                `资料卡点赞：${data.times}次`,
+                `${data.self_id} <= ${data.operator_id}`,
+                true
+              )
+              break
+            default:
+              Bot.makeLog("warn", `未知通知：${logger.magenta(data.raw)}`, data.self_id)
+          }
+          break
+        case "group_card":
+          Bot.makeLog(
+            "info",
+            `群名片更新：${data.card_old} => ${data.card_new}`,
+            `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+            true
+          )
+          data.bot.pickMember(data.group_id, data.user_id).getInfo()
+          break
+        case "offline_file":
+          Bot.makeLog(
+            "info",
+            `离线文件：${Bot.String(data.file)}`,
+            `${data.self_id} <= ${data.user_id}`,
+            true
+          )
+          Bot.em("message.private.friend", {
+            ...data,
+            post_type: "message",
+            message_type: "private",
+            sub_type: "friend",
+            message: [{ ...data.file, type: "file" }],
+            raw_message: `[文件：${data.file.name}]`
+          })
+          break
+        case "client_status":
+          Bot.makeLog(
+            "info",
+            `客户端${data.online ? "上线" : "下线"}：${Bot.String(data.client)}`,
+            data.self_id
+          )
+          data.clients = (await data.bot.sendApi("get_online_clients")).clients
+          data.bot.clients = data.clients
+          break
+        case "essence":
+          data.notice_type = "group_essence"
+          Bot.makeLog(
+            "info",
+            `群精华消息：${data.operator_id} => ${data.sender_id} ${data.sub_type} ${data.message_id}`,
+            `${data.self_id} <= ${data.group_id}`,
+            true
+          )
+          break
+        case "guild_channel_recall":
+          Bot.makeLog(
+            "info",
+            `频道消息撤回：${data.operator_id} => ${data.user_id} ${data.message_id}`,
+            `${data.self_id} <= ${data.guild_id}-${data.channel_id}`,
+            true
+          )
+          break
+        case "message_reactions_updated":
+          data.notice_type = "guild_message_reactions_updated"
+          Bot.makeLog(
+            "info",
+            `频道消息表情贴：${data.message_id} ${Bot.String(data.current_reactions)}`,
+            `${data.self_id} <= ${data.guild_id}-${data.channel_id}, ${data.user_id}`,
+            true
+          )
+          break
+        case "channel_updated":
+          data.notice_type = "guild_channel_updated"
+          Bot.makeLog(
+            "info",
+            `子频道更新：${Bot.String(data.old_info)} => ${Bot.String(data.new_info)}`,
+            `${data.self_id} <= ${data.guild_id}-${data.channel_id}, ${data.user_id}`,
+            true
+          )
+          break
+        case "channel_created":
+          data.notice_type = "guild_channel_created"
+          Bot.makeLog(
+            "info",
+            `子频道创建：${Bot.String(data.channel_info)}`,
+            `${data.self_id} <= ${data.guild_id}-${data.channel_id}, ${data.user_id}`,
+            true
+          )
+          data.bot.getGroupMap()
+          break
+        case "channel_destroyed":
+          data.notice_type = "guild_channel_destroyed"
+          Bot.makeLog(
+            "info",
+            `子频道删除：${Bot.String(data.channel_info)}`,
+            `${data.self_id} <= ${data.guild_id}-${data.channel_id}, ${data.user_id}`,
+            true
+          )
+          data.bot.getGroupMap()
+          break
+        case "bot_offline":
+          data.post_type = "system"
+          data.notice_type = "offline"
+          Bot.makeLog("info", `${data.tag || "账号下线"}：${data.message}`, data.self_id)
+          Bot.sendMasterMsg(`[${data.self_id}] ${data.tag || "账号下线"}：${data.message}`)
+          break
+        default:
+          Bot.makeLog("warn", `未知通知：${logger.magenta(data.raw)}`, data.self_id)
+      }
+
+      let notice = data.notice_type.split("_")
+      data.notice_type = notice.shift()
+      notice = notice.join("_")
+      if (notice) data.sub_type = notice
+
+      if (data.guild_id && data.channel_id) {
+        data.group_id = `${data.guild_id}-${data.channel_id}`
+        Object.defineProperty(data, "friend", {
+          get () {
+            return this.member || {}
+          }
+        })
+      }
+
+      Bot.em(`${data.post_type}.${data.notice_type}.${data.sub_type}`, data)
+    }
+
+    makeRequest (data) {
+      switch (data.request_type) {
+        case "friend":
+          Bot.makeLog(
+            "info",
+            `加好友请求：${data.comment}(${data.flag})`,
+            `${data.self_id} <= ${data.user_id}`,
+            true
+          )
+          data.sub_type = "add"
+          data.approve = function (approve, remark) {
+            return this.bot.setFriendAddRequest(this.flag, approve, remark)
+          }
+          break
+        case "group":
+          Bot.makeLog(
+            "info",
+            `加群请求：${data.sub_type} ${data.comment}(${data.flag})`,
+            `${data.self_id} <= ${data.group_id}, ${data.user_id}`,
+            true
+          )
+          data.approve = function (approve, reason) {
+            return this.bot.setGroupAddRequest(this.flag, approve, reason, this.sub_type)
+          }
+          break
+        default:
+          Bot.makeLog("warn", `未知请求：${logger.magenta(data.raw)}`, data.self_id)
+      }
+
+      data.bot.request_list.push(data)
+      Bot.em(`${data.post_type}.${data.request_type}.${data.sub_type}`, data)
+    }
+
+    heartbeat (data) {
+      if (data.status) Object.assign(data.bot.stat, data.status)
+    }
+
+    makeMeta (data, ws) {
+      switch (data.meta_event_type) {
+        case "heartbeat":
+          this.heartbeat(data)
+          break
+        case "lifecycle":
+          this.connect(data, ws)
+          break
+        default:
+          Bot.makeLog("warn", `未知消息：${logger.magenta(data.raw)}`, data.self_id)
+      }
+    }
+
+    message (data, ws) {
+      try {
+        data = {
+          ...JSON.parse(data),
+          raw: Bot.String(data)
+        }
+      } catch (err) {
+        return Bot.makeLog("error", ["解码数据失败", data, err])
+      }
+
+      if (data.post_type) {
+        if (data.meta_event_type !== "lifecycle" && !Bot.uin.includes(data.self_id)) {
+          Bot.makeLog("warn", `找不到对应Bot，忽略消息：${logger.magenta(data.raw)}`, data.self_id)
+          return false
+        }
+        data.bot = Bot[data.self_id]
+
+        switch (data.post_type) {
+          case "meta_event":
+            return this.makeMeta(data, ws)
+          case "message":
+            return this.makeMessage(data)
+          case "notice":
+            return this.makeNotice(data)
+          case "request":
+            return this.makeRequest(data)
+          case "message_sent":
+            data.post_type = "message"
+            return this.makeMessage(data)
+        }
+      } else if (data.echo) {
+        const cache = this.echo.get(data.echo)
+        if (cache) return cache.resolve(data)
+      }
+      Bot.makeLog("warn", `未知消息：${logger.magenta(data.raw)}`, data.self_id)
+    }
+
+    bindClient (client) {
+      this.client = client
+      return this
+    }
+  }
+
+export default OneBotAppClientAdapter

--- a/model/onebot/AppClientAdapter.js
+++ b/model/onebot/AppClientAdapter.js
@@ -14,6 +14,31 @@ class OneBotAppClientAdapter {
       return Bot.String(msg).replace(/base64:\/\/.*?(,|]|")/g, "base64://...$1")
     }
 
+    normalizeSelfId (self_id) {
+      return Number(self_id) || self_id
+    }
+
+    setClientSelfId (self_id) {
+      if (!this.client) return
+      this.client.appSelfId = self_id
+      this.client.self_id = self_id
+    }
+
+    hasSelfId (self_id) {
+      if (!self_id) return false
+      const id = String(self_id)
+      const list = Array.isArray(Bot.uin) ? Bot.uin : [Bot.uin].filter(Boolean)
+      return list.some(i => String(i) === id) && !!Bot[self_id]
+    }
+
+    addSelfId (self_id) {
+      if (Array.isArray(Bot.uin)) {
+        if (!Bot.uin.some(i => String(i) === String(self_id))) Bot.uin.push(self_id)
+      } else if (String(Bot.uin) !== String(self_id)) {
+        Bot.uin = [Bot.uin, self_id].filter(Boolean)
+      }
+    }
+
     sendApi (data, ws, action, params = {}) {
       const echo = randomUUID()
       const request = { action, params, echo }
@@ -850,9 +875,83 @@ class OneBotAppClientAdapter {
       }
     }
 
-    async connect (data, ws) {
+    async connectEndpoint (ws, selfIdHint) {
+      const time = Math.floor(Date.now() / 1000)
+      const hint = this.normalizeSelfId(selfIdHint)
+      const probe = {
+        self_id: hint || 0,
+        time
+      }
+      const info = await this.sendApi(probe, ws, "get_login_info").catch(error => {
+        if (!hint) throw error
+        Bot.makeLog("warn", ["获取登录信息失败，使用连接地址中的self_id", error], hint)
+        return {
+          user_id: hint,
+          nickname: hint
+        }
+      })
+      const self_id = this.normalizeSelfId(info?.user_id || hint)
+      if (!self_id) throw Bot.makeError("无法确定OneBot账号", { action: "get_login_info" }, { info })
+      await this.connect({ self_id, time }, ws, info)
+    }
+
+    async finishConnect (data, loginInfo, warmup) {
+      data.bot.info = loginInfo || (warmup
+        ? await data.bot.sendApi("get_login_info").catch(() => ({
+          user_id: data.self_id,
+          nickname: data.self_id
+        }))
+        : data.bot.info?.user_id
+          ? data.bot.info
+          : {
+              user_id: data.self_id,
+              nickname: data.self_id
+            })
+      data.bot.clients ??= []
+      if (!warmup) {
+        data.bot.version ??= {
+          id: this.id,
+          name: this.name,
+          version: this.name
+        }
+        return
+      }
+      if (data.bot.__onebotAppReady) return
+      data.bot.version = {
+        ...((await data.bot.sendApi("get_version_info").catch(() => ({}))) || {}),
+        id: this.id,
+        name: this.name,
+        get version () {
+          return this.app_full_name || `${this.app_name} v${this.app_version}`
+        }
+      }
+
+      data.bot.getFriendMap().catch(err => {
+        Bot.makeLog("warn", ["获取好友列表失败", err], data.self_id)
+      })
+      data.bot.getGroupMap().catch(err => {
+        Bot.makeLog("warn", ["获取群列表失败", err], data.self_id)
+      })
+
+      data.bot.__onebotAppReady = true
+      Bot.makeLog(
+        "mark",
+        `${this.name}(${this.id}) ${data.bot.version.version} 已连接`,
+        data.self_id
+      )
+      Bot.em(`connect.${data.self_id}`, data)
+    }
+
+    async connect (data, ws, loginInfo, options = {}) {
+      const { warmup = true } = options
+      data.self_id = this.normalizeSelfId(data.self_id)
       if (Bot[data.self_id]) {
         data.bot = Bot[data.self_id]
+        data.bot.ws = ws
+        data.bot.sendApi = this.sendApi.bind(this, data, ws)
+        this.addSelfId(data.self_id)
+        this.setClientSelfId(data.self_id)
+        await this.finishConnect(data, loginInfo, warmup)
         return
       }
       Bot[data.self_id] = {
@@ -936,39 +1035,10 @@ class OneBotAppClientAdapter {
       }
       data.bot = Bot[data.self_id]
 
-      if (Array.isArray(Bot.uin)) {
-        if (!Bot.uin.includes(data.self_id)) Bot.uin.push(data.self_id)
-      } else if (Bot.uin !== data.self_id) {
-        Bot.uin = [Bot.uin, data.self_id].filter(Boolean)
-      }
+      this.addSelfId(data.self_id)
+      this.setClientSelfId(data.self_id)
 
-      data.bot.info = await data.bot.sendApi("get_login_info").catch(() => ({
-        user_id: data.self_id,
-        nickname: data.self_id
-      }))
-      data.bot.clients = []
-      data.bot.version = {
-        ...((await data.bot.sendApi("get_version_info").catch(() => ({}))) || {}),
-        id: this.id,
-        name: this.name,
-        get version () {
-          return this.app_full_name || `${this.app_name} v${this.app_version}`
-        }
-      }
-
-      data.bot.getFriendMap().catch(err => {
-        Bot.makeLog("warn", ["获取好友列表失败", err], data.self_id)
-      })
-      data.bot.getGroupMap().catch(err => {
-        Bot.makeLog("warn", ["获取群列表失败", err], data.self_id)
-      })
-
-      Bot.makeLog(
-        "mark",
-        `${this.name}(${this.id}) ${data.bot.version.version} 已连接`,
-        data.self_id
-      )
-      Bot.em(`connect.${data.self_id}`, data)
+      await this.finishConnect(data, loginInfo, warmup)
     }
 
     makeMessage (data) {
@@ -1337,20 +1407,20 @@ class OneBotAppClientAdapter {
       if (data.status) Object.assign(data.bot.stat, data.status)
     }
 
-    makeMeta (data, ws) {
+    async makeMeta (data, ws) {
       switch (data.meta_event_type) {
         case "heartbeat":
           this.heartbeat(data)
           break
         case "lifecycle":
-          this.connect(data, ws)
+          await this.connect(data, ws)
           break
         default:
           Bot.makeLog("warn", `未知消息：${logger.magenta(data.raw)}`, data.self_id)
       }
     }
 
-    message (data, ws) {
+    async message (data, ws) {
       try {
         data = {
           ...JSON.parse(data),
@@ -1361,9 +1431,15 @@ class OneBotAppClientAdapter {
       }
 
       if (data.post_type) {
-        if (data.meta_event_type !== "lifecycle" && !Bot.uin.includes(data.self_id)) {
-          Bot.makeLog("warn", `找不到对应Bot，忽略消息：${logger.magenta(data.raw)}`, data.self_id)
-          return false
+        data.self_id = this.normalizeSelfId(data.self_id)
+        if (data.meta_event_type !== "lifecycle" && !this.hasSelfId(data.self_id)) {
+          await this.connect({
+            self_id: data.self_id,
+            time: data.time || Math.floor(Date.now() / 1000)
+          }, ws, {
+            user_id: data.self_id,
+            nickname: data.self_id
+          }, { warmup: false })
         }
         data.bot = Bot[data.self_id]
 

--- a/model/onebot/AppClientAdapter.js
+++ b/model/onebot/AppClientAdapter.js
@@ -1103,6 +1103,23 @@ class OneBotAppClientAdapter {
             true
           )
           break
+        case "friend_decrease":
+          Bot.makeLog(
+            "info",
+            `好友减少：${data.nickname || data.user_id}`,
+            `${data.self_id} <= ${data.user_id}`,
+            true
+          )
+          data.bot.fl.delete(data.user_id)
+          break
+        case "input_status":
+          data.post_type = "internal"
+          data.notice_type = "input"
+          data.sub_type = "input_status"
+          data.end ??= data.event_type !== 1
+          data.message ||= data.status_text || `对方${data.end ? "结束" : "正在"}输入...`
+          Bot.makeLog("info", data.message, `${data.self_id} <= ${data.user_id}`, true)
+          break
         case "group_recall":
           Bot.makeLog(
             "info",
@@ -1150,6 +1167,17 @@ class OneBotAppClientAdapter {
           data.set = data.sub_type === "set"
           data.bot.pickMember(data.group_id, data.user_id).getInfo()
           break
+        case "group_transfer":
+          Bot.makeLog(
+            "info",
+            `群主转让：${data.operator_id} => ${data.user_id}`,
+            `${data.self_id} <= ${data.group_id}`,
+            true
+          )
+          data.bot.pickGroup(data.group_id).getInfo()
+          data.bot.pickMember(data.group_id, data.user_id).getInfo()
+          if (data.operator_id) data.bot.pickMember(data.group_id, data.operator_id).getInfo()
+          break
         case "group_upload":
           Bot.makeLog(
             "info",
@@ -1174,6 +1202,31 @@ class OneBotAppClientAdapter {
             true
           )
           data.bot.pickMember(data.group_id, data.user_id).getInfo()
+          break
+        case "group_sign":
+          Bot.makeLog(
+            "info",
+            `群打卡：${data.nickname || data.user_id} ${data.sign_text || ""}`,
+            `${data.self_id} <= ${data.group_id}`,
+            true
+          )
+          break
+        case "group_read":
+          Bot.makeLog(
+            "info",
+            `群消息已读：${data.seq}`,
+            `${data.self_id} <= ${data.group_id}`,
+            true
+          )
+          break
+        case "group_reaction":
+          data.message_id ??= data.seq
+          Bot.makeLog(
+            "info",
+            `群消息回应：${data.user_id} ${data.set ? "添加" : "取消"} ${data.type || data.id}`,
+            `${data.self_id} <= ${data.group_id}`,
+            true
+          )
           break
         case "group_msg_emoji_like":
           Bot.makeLog(
@@ -1205,6 +1258,22 @@ class OneBotAppClientAdapter {
               { Bot.makeLog(
                 "info",
                   `好友戳一戳：${data.operator_id} => ${data.target_id}`,
+                  data.self_id
+              ) }
+              break
+            case "poke_recall":
+              data.operator_id = data.user_id
+              if (data.group_id)
+              { Bot.makeLog(
+                "info",
+                  `群戳一戳撤回：${data.operator_id} => ${data.target_id}`,
+                  `${data.self_id} <= ${data.group_id}`,
+                  true
+              ) }
+              else
+              { Bot.makeLog(
+                "info",
+                  `好友戳一戳撤回：${data.operator_id} => ${data.target_id}`,
                   data.self_id
               ) }
               break

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1242 @@
+{
+  "name": "ws-plugin",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ws-plugin",
+      "version": "1.0.0",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "express": "^5.2.1",
+        "lodash": "^4.17.21",
+        "qrcode": "^1.5.4",
+        "silk-wasm": "3.7.1",
+        "ws": "^8.20.0",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/silk-wasm": {
+      "version": "3.7.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/silk-wasm/-/silk-wasm-3.7.1.tgz",
+      "integrity": "sha512-mXPwLRtZxrYV3TZx41jMAeKc80wvmyrcXIcs8HctFxK15Ahz2OJQENYhNgEPeCEOdI6Mbx1NxQsqxzwc3DKerw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://mirrors.cloud.tencent.com/npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "main": "index.js",
   "type": "module",
   "dependencies": {
+    "chokidar": "^5.0.0",
     "express": "^5.2.1",
+    "lodash": "^4.17.21",
     "qrcode": "^1.5.4",
     "silk-wasm": "3.7.1",
-    "ws": "^8.20.0"
+    "ws": "^8.20.0",
+    "yaml": "^2.9.0"
   },
   "author": "xiaoye12123"
 }


### PR DESCRIPTION
## 变更说明

- 新增 `type: 7` 连接类型：`OneBot应用端ws`。
- 该模式下 ws-plugin 作为 OneBot 应用端/处理器，主动连接 OneBot 实现端。
- 收到 OneBot v11 的 `message` / `notice` / `request` / `meta_event` 上报后，转换为 Yunzai 的 `Bot.em(...)` 事件。
- Yunzai 插件发送消息、撤回、取列表等操作时，通过 OneBot action 请求回到实现端。
- 不改变现有 `type: 1` / `type: 2` 的行为，避免影响已有用法。
- 新模式启动时只拉取登录信息、版本、好友列表和群列表；默认不全量预热群成员，避免连接后产生大量 `get_group_member_list` 请求。
- 补充原项目运行时已使用但 `package.json` 未声明的依赖：`lodash`、`yaml`、`chokidar`。

## 使用方式

连接 OneBot 实现端时使用 `type: 7`，例如：

```text
连接名字,7
wss://example.com/OneBotv11/123456,5,0,access-token
```

其中参数含义为：

```text
连接地址,重连间隔,最大重连次数,access-token
```

## 和原有类型的区别

- `type: 1`：ws-plugin 作为 OneBot 实现端，主动连接 OneBot 应用端。
- `type: 2`：ws-plugin 作为 OneBot 实现端，本地监听 OneBot 应用端连接。
- `type: 7`：ws-plugin 作为 OneBot 应用端，主动连接 OneBot 实现端。

## 验证

- 已对修改后的 JS 入口执行 `node --check`。
- 已做本地 adapter smoke，确认 OneBot `post_type: message` 能转换为 Yunzai 的 `message.group.normal` 事件。